### PR TITLE
Add article caching and fetching from external APIs

### DIFF
--- a/src/services/article_service.rs
+++ b/src/services/article_service.rs
@@ -1,0 +1,36 @@
+use reqwest::Error;
+use redis::AsyncCommands;
+use crate::{AppState, models::Article, enums::AppError};
+
+pub async fn fetch_article_content(title: &str, source: &str) -> Result<String, Error> {
+    match source {
+        "wikipedia" => fetch_wikipedia_article(title).await,
+        "fandom" => fetch_fandom_article(title).await,
+        _ => Err(Error::new(reqwest::StatusCode::BAD_REQUEST, "Invalid source")),
+    }
+}
+
+async fn fetch_wikipedia_article(title: &str) -> Result<String, Error> {
+    let url = format!("https://en.wikipedia.org/api/rest_v1/page/summary/{}", title);
+    let response = reqwest::get(&url).await?;
+    let json: serde_json::Value = response.json().await?;
+    Ok(json["extract"].as_str().unwrap_or("").to_string())
+}
+
+async fn fetch_fandom_article(title: &str) -> Result<String, Error> {
+    let url = format!("https://{}.fandom.com/api.php?action=query&prop=extracts&exintro&titles={}&format=json", title);
+    let response = reqwest::get(&url).await?;
+    let json: serde_json::Value = response.json().await?;
+    let pages = json["query"]["pages"].as_object().unwrap();
+    let extract = pages.values().next().unwrap()["extract"].as_str().unwrap_or("").to_string();
+    Ok(extract)
+}
+
+// Function to cache article content in Redis
+pub async fn cache_article_content(state: &AppState, article: &Article) -> Result<(), AppError> {
+    let mut conn = state.redis.get_async_connection().await?;
+    let key = format!("article:{}", article.id);
+    let value = serde_json::to_string(article)?;
+    conn.set_ex(key, value, 3600).await?;
+    Ok(())
+}

--- a/src/tests/article_tests.rs
+++ b/src/tests/article_tests.rs
@@ -1,0 +1,50 @@
+use super::*;
+use tokio::runtime::Runtime;
+use crate::services::article_service::{fetch_article_content, cache_article_content};
+use crate::models::Article;
+use crate::AppState;
+use uuid::Uuid;
+use time::OffsetDateTime;
+use std::sync::Arc;
+use crate::config::Config;
+use redis::Client;
+
+#[test]
+fn test_fetch_article_content_wikipedia() {
+    let rt = Runtime::new().unwrap();
+    let result = rt.block_on(fetch_article_content("Rust_(programming_language)", "wikipedia"));
+    assert!(result.is_ok());
+    assert!(result.unwrap().contains("Rust is a multi-paradigm"));
+}
+
+#[test]
+fn test_fetch_article_content_fandom() {
+    let rt = Runtime::new().unwrap();
+    let result = rt.block_on(fetch_article_content("Harry_Potter", "fandom"));
+    assert!(result.is_ok());
+    assert!(result.unwrap().contains("Harry Potter is a series of seven fantasy novels"));
+}
+
+#[test]
+fn test_cache_article_content() {
+    let rt = Runtime::new().unwrap();
+    let config = Config::load().unwrap();
+    let redis_client = Client::open(config.redis_url.clone()).unwrap();
+    let state = AppState {
+        config: Arc::new(config),
+        redis: redis_client,
+    };
+
+    let article = Article {
+        id: Uuid::new_v4(),
+        title: "Test Article".to_string(),
+        summary: "This is a test article".to_string(),
+        content: "Test content".to_string(),
+        author_id: Uuid::new_v4(),
+        created_at: OffsetDateTime::now_utc(),
+        updated_at: OffsetDateTime::now_utc(),
+    };
+
+    let result = rt.block_on(cache_article_content(&state, &article));
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Implement the mechanism to fetch articles from Wikipedia and Fandom, and cache them in Redis.

* **Fetch Article Content:**
  - Add `fetch_article_content` function in `src/services/article_service.rs` to fetch article content from Wikipedia and Fandom.
  - Modify `create_article` function in `src/api/article.rs` to use `fetch_article_content` for content.

* **Cache Article Content:**
  - Add `cache_article_content` function in `src/services/article_service.rs` to cache article content in Redis.
  - Modify `create_article` function in `src/api/article.rs` to cache the article content in Redis.

* **Unit Tests:**
  - Add unit tests for `fetch_article_content` and `cache_article_content` functions in `src/tests/article_tests.rs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NibbleKnow/backend/pull/3?shareId=3098019f-8b56-47ae-a2d7-89c71677f019).